### PR TITLE
Fix reply defer not working

### DIFF
--- a/src/main/java/dev/coly/jdat/entities/events/FakeSlashCommandEvent.java
+++ b/src/main/java/dev/coly/jdat/entities/events/FakeSlashCommandEvent.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.internal.interactions.CommandInteractionImpl;
 import net.dv8tion.jda.internal.interactions.InteractionHookImpl;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -52,7 +53,7 @@ public class FakeSlashCommandEvent extends SlashCommandEvent {
 
     @NotNull
     @Override
-    public ReplyAction replyEmbeds(@NotNull MessageEmbed embed, @NotNull MessageEmbed... embeds) {
+    public ReplyAction replyEmbeds(@NotNull MessageEmbed embed, MessageEmbed @NotNull ... embeds) {
         List<MessageEmbed> list = new LinkedList<>(Arrays.asList(embeds));
         list.add(embed);
         return replyEmbeds(list);
@@ -60,14 +61,15 @@ public class FakeSlashCommandEvent extends SlashCommandEvent {
 
     @NotNull
     @Override
-    public ReplyAction replyFormat(@NotNull String format, @NotNull Object... args) {
+    public ReplyAction replyFormat(@NotNull String format, Object @NotNull ... args) {
         return reply(String.format(format, args));
     }
 
     @NotNull
     @Override
     public ReplyAction deferReply() {
-        return new FakeReplyAction((InteractionHookImpl) this.interaction.getHook(), null).setDefer(true);
+        this.replyAction = new FakeReplyAction((InteractionHookImpl) this.interaction.getHook(), null);
+        return replyAction.setDefer(true);
     }
 
     @NotNull

--- a/src/test/java/dev/coly/jdat/TestEventListener.java
+++ b/src/test/java/dev/coly/jdat/TestEventListener.java
@@ -19,7 +19,7 @@ public class TestEventListener implements EventListener {
             if (e.getMessage().getContentDisplay().equals(".ping")) {
                 e.getChannel().sendMessage("Pong!").queue();
             } else if (e.getMessage().getContentDisplay().equals(".embed")) {
-                e.getChannel().sendMessage(getTestEmbed()).queue();
+                e.getChannel().sendMessageEmbeds(getTestEmbed()).queue();
             }
         } else if (event instanceof SlashCommandEvent) {
             SlashCommandEvent e = (SlashCommandEvent) event;
@@ -35,6 +35,10 @@ public class TestEventListener implements EventListener {
                             " - str: " + Objects.requireNonNull(e.getOption("str")).getAsString() +
                             " - number: " + Objects.requireNonNull(e.getOption("number")).getAsLong() +
                             " - user: " + Objects.requireNonNull(e.getOption("user")).getAsUser().getAsTag()).queue();
+                    break;
+                case "defer":
+                    e.deferReply().queue();
+                    break;
             }
         }
     }

--- a/src/test/java/dev/coly/jdat/TestGuildMessageReceivedEvent.java
+++ b/src/test/java/dev/coly/jdat/TestGuildMessageReceivedEvent.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-public class TestJDATesting {
+public class TestGuildMessageReceivedEvent {
 
     @Test
     public void testTestGuildMessageReceivedEvent() {
@@ -42,28 +42,6 @@ public class TestJDATesting {
     @Test
     public void testAssertGuildMessageReceivedEventWithEmbeds() {
         JDATesting.assertGuildMessageReceivedEvent(new TestEventListener(), ".embed",
-                new ArrayList<>(Collections.singleton(TestEventListener.getTestEmbed())));
-    }
-
-    @Test
-    public void testAssertSlashCommandEvent() {
-        JDATesting.assertSlashCommandEvent(new TestEventListener(), "ping", new HashMap<>(), "Pong!");
-    }
-
-    @Test
-    public void testAssertSlashCommandEventWithOptions() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("bool", true);
-        map.put("str", "text");
-        map.put("number", 42);
-        map.put("user", JDAObjects.getFakeUser());
-        JDATesting.assertSlashCommandEvent(new TestEventListener(), "options", map,
-                "bool: true - str: text - number: 42 - user: User#0000");
-    }
-
-    @Test
-    public void testAssertSlashCommandEventWithEmbeds() {
-        JDATesting.assertSlashCommandEvent(new TestEventListener(), "embed", new HashMap<>(),
                 new ArrayList<>(Collections.singleton(TestEventListener.getTestEmbed())));
     }
 

--- a/src/test/java/dev/coly/jdat/TestSlashCommands.java
+++ b/src/test/java/dev/coly/jdat/TestSlashCommands.java
@@ -1,0 +1,49 @@
+package dev.coly.jdat;
+
+import dev.coly.jdat.entities.actions.FakeReplyAction;
+import dev.coly.jdat.entities.events.FakeSlashCommandEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestSlashCommands {
+
+    @Test
+    public void testAssertSlashCommandEvent() {
+        JDATesting.assertSlashCommandEvent(new TestEventListener(), "ping", new HashMap<>(), "Pong!");
+    }
+
+    @Test
+    public void testAssertSlashCommandEventWithOptions() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("bool", true);
+        map.put("str", "text");
+        map.put("number", 42);
+        map.put("user", JDAObjects.getFakeUser());
+        JDATesting.assertSlashCommandEvent(new TestEventListener(), "options", map,
+                "bool: true - str: text - number: 42 - user: User#0000");
+    }
+
+    @Test
+    public void testAssertSlashCommandEventWithEmbeds() {
+        JDATesting.assertSlashCommandEvent(new TestEventListener(), "embed", new HashMap<>(),
+                new ArrayList<>(Collections.singleton(TestEventListener.getTestEmbed())));
+    }
+
+    @Test
+    public void testSlashCommandWithDeferReply() {
+        FakeSlashCommandEvent event = JDAObjects.getFakeSlashCommandEvent("defer", 0, new HashMap<>());
+        new TestEventListener().onEvent(event);
+        try {
+            FakeReplyAction action = event.awaitReturn();
+            Assertions.assertTrue(action.isDefer());
+        } catch (InterruptedException e) {
+            Assertions.fail(e);
+        }
+    }
+
+}


### PR DESCRIPTION
A defer replay with `.deferReply().queue()` on slash command would result in a NullPointerException. This was fixed in this command and a test for this has been implemented.