### PR TITLE
Support multiple value callback

### DIFF
--- a/src/main/java/dev/coly/jdat/JDAObjects.java
+++ b/src/main/java/dev/coly/jdat/JDAObjects.java
@@ -64,7 +64,7 @@ public class JDAObjects {
                                                                                Map<String, Object> options,
                                                                                Callback<Message> messageCallback) {
         return getSlashCommandInteractionEvent(channel, name, subcommandName, subcommandGroup, options, messageCallback,
-                new Callback<>());
+                Callback.single());
     }
 
     /**

--- a/src/main/java/dev/coly/jdat/JDATesting.java
+++ b/src/main/java/dev/coly/jdat/JDATesting.java
@@ -33,7 +33,7 @@ public class JDATesting {
      *                              interrupted if the thread is interrupted.
      */
     public static Message testMessageReceivedEvent(EventListener listener, String input) throws InterruptedException {
-        Callback<Message> messageCallback = new Callback<>();
+        Callback<Message> messageCallback = Callback.single();
 
         MessageChannel channel = JDAObjects.getMessageChannel("test-chanel", 0L, messageCallback);
         Message message = JDAObjects.getMessage(input, new ArrayList<>(), channel);
@@ -80,7 +80,7 @@ public class JDATesting {
     public static Message testSlashCommandEvent(EventListener listener, String name, String subcommand,
                                              String subcommandGroup, Map<String, Object> options)
             throws InterruptedException {
-        Callback<Message> messageCallback = new Callback<>();
+        Callback<Message> messageCallback = Callback.single();
 
         MessageChannel channel = JDAObjects.getMessageChannel("test-chanel", 0L, messageCallback);
         SlashCommandInteractionEvent event = JDAObjects.getSlashCommandInteractionEvent(channel, name, subcommand,

--- a/src/main/java/dev/coly/util/Callback.java
+++ b/src/main/java/dev/coly/util/Callback.java
@@ -1,32 +1,24 @@
 package dev.coly.util;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class Callback<T> {
+public interface Callback<T> {
 
-    private final CountDownLatch countDownLatch;
-    private T object;
-
-    public Callback() {
-        this.countDownLatch = new CountDownLatch(1);
+    static <T> Callback<T> single() {
+        return new SingleCallback<>();
     }
 
-    public void callback(T object) {
-        this.object = object;
-        this.countDownLatch.countDown();
+    static <T> Callback<T> multiple() {
+        return new MultipleCallback<>();
     }
 
-    public T await() throws InterruptedException {
-        this.countDownLatch.await();
-        return object;
+    static <T> Callback<T> multiple(int count) {
+        return new MultipleCallback<>(count);
     }
 
-    public T await(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        if (!this.countDownLatch.await(timeout, timeUnit)) {
-            throw new InterruptedException("Timeout elapsed");
-        }
-        return object;
-    }
+    void callback(T object);
 
+    T await() throws InterruptedException;
+
+    T await(long timeout, TimeUnit timeUnit) throws InterruptedException;
 }

--- a/src/main/java/dev/coly/util/MultipleCallback.java
+++ b/src/main/java/dev/coly/util/MultipleCallback.java
@@ -1,0 +1,32 @@
+package dev.coly.util;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public class MultipleCallback<T> implements Callback<T> {
+    private final BlockingQueue<T> queue;
+
+    public MultipleCallback() {
+        this(Integer.MAX_VALUE);
+    }
+
+    public MultipleCallback(int count) {
+        this.queue = new LinkedBlockingQueue<>(count);
+    }
+
+    @Override
+    public void callback(T object) {
+        queue.add(object);
+    }
+
+    @Override
+    public T await() throws InterruptedException {
+        return queue.take();
+    }
+
+    @Override
+    public T await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return queue.poll(timeout, timeUnit);
+    }
+}

--- a/src/main/java/dev/coly/util/SingleCallback.java
+++ b/src/main/java/dev/coly/util/SingleCallback.java
@@ -1,0 +1,30 @@
+package dev.coly.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SingleCallback<T> implements Callback<T> {
+    private final CountDownLatch countDownLatch;
+    private T object;
+
+    public SingleCallback() {
+        this.countDownLatch = new CountDownLatch(1);
+    }
+
+    public void callback(T object) {
+        this.object = object;
+        this.countDownLatch.countDown();
+    }
+
+    public T await() throws InterruptedException {
+        this.countDownLatch.await();
+        return object;
+    }
+
+    public T await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        if (!this.countDownLatch.await(timeout, timeUnit)) {
+            throw new InterruptedException("Timeout elapsed");
+        }
+        return object;
+    }
+}

--- a/src/test/java/dev/coly/jdat/TestJDAObjects.java
+++ b/src/test/java/dev/coly/jdat/TestJDAObjects.java
@@ -39,7 +39,7 @@ public class TestJDAObjects {
         map.put("int", 1);
         map.put("double", 1d);
         SlashCommandInteractionEvent event = JDAObjects.getSlashCommandInteractionEvent(null, "command",
-                "subcommand", "subcommandGroup", map, new Callback<>());
+                "subcommand", "subcommandGroup", map, Callback.single());
         Assertions.assertEquals("penis", Objects.requireNonNull(event.getOption("string")).getAsString());
         Assertions.assertTrue(Objects.requireNonNull(event.getOption("boolean")).getAsBoolean());
         Assertions.assertEquals(1L, Objects.requireNonNull(event.getOption("long")).getAsLong());
@@ -50,7 +50,7 @@ public class TestJDAObjects {
     @Test
     public void testGetGuildChannelUnion() {
         GuildChannelUnion guildChannelUnion = JDAObjects.getGuildChannelUnion("test-channel", 42,
-                new Callback<>());
+                Callback.single());
         Assertions.assertEquals("test-channel", guildChannelUnion.getName());
         Assertions.assertEquals("42", guildChannelUnion.getId());
         Assertions.assertEquals(42, guildChannelUnion.getIdLong());

--- a/src/test/java/dev/coly/jdat/TestSlashCommands.java
+++ b/src/test/java/dev/coly/jdat/TestSlashCommands.java
@@ -43,8 +43,8 @@ public class TestSlashCommands {
         Map<String, Object> options = new HashMap<>();
         options.put("test", true);
         SlashCommandInteractionEvent event = JDAObjects.getSlashCommandInteractionEvent(
-                JDAObjects.getMessageChannel("test-channel", 1L, new Callback<>()), "slash-command",
-                "subcommand", "subcommand-group", options, new Callback<>());
+                JDAObjects.getMessageChannel("test-channel", 1L, Callback.single()), "slash-command",
+                "subcommand", "subcommand-group", options, Callback.single());
         Assertions.assertNotNull(event.getChannel());
         Assertions.assertEquals("test-channel", event.getChannel().getName());
         Assertions.assertEquals("slash-command", event.getName());
@@ -58,10 +58,10 @@ public class TestSlashCommands {
     public void testSlashCommandWithDeferReply() {
         Map<String, Object> options = new HashMap<>();
         options.put("test", true);
-        Callback<Boolean> callback = new Callback<>();
+        Callback<Boolean> callback = Callback.single();
         SlashCommandInteractionEvent event = JDAObjects.getSlashCommandInteractionEvent(
-                JDAObjects.getMessageChannel("test-channel", 1L, new Callback<>()), "defer",
-                "subcommand", "subcommand-group", options, new Callback<>(), callback);
+                JDAObjects.getMessageChannel("test-channel", 1L, Callback.single()), "defer",
+                "subcommand", "subcommand-group", options, Callback.single(), callback);
         new TestEventListener().onEvent(event);
         try {
             Assertions.assertFalse(callback.await(100L, TimeUnit.MILLISECONDS));
@@ -72,7 +72,7 @@ public class TestSlashCommands {
 
     @Test
     public void testSlashCommandWithEphemeral() {
-        Callback<Message> callback = new Callback<>();
+        Callback<Message> callback = Callback.single();
         MessageChannel messageChannel = JDAObjects.getMessageChannel("channel", 1L, callback);
         SlashCommandInteractionEvent event = JDAObjects.getSlashCommandInteractionEvent(messageChannel, "ephemeral",
                 null, null, null, callback);

--- a/src/test/java/dev/coly/util/TestCallback.java
+++ b/src/test/java/dev/coly/util/TestCallback.java
@@ -9,7 +9,7 @@ public class TestCallback {
 
     @Test
     public void testCallback() {
-        Callback<String> callback = new Callback<>();
+        Callback<String> callback = Callback.single();
         methodCallback(callback);
         try {
             Assertions.assertEquals("test", callback.await());
@@ -20,7 +20,7 @@ public class TestCallback {
 
     @Test
     public void testCallbackTimeout() {
-        Callback<String> callback = new Callback<>();
+        Callback<String> callback = Callback.single();
         methodCallback(callback);
         try {
             Assertions.assertEquals("test", callback.await(1000L, TimeUnit.MILLISECONDS));
@@ -32,7 +32,7 @@ public class TestCallback {
     @Test
     public void testCallbackTimeoutFailed() {
         Assertions.assertThrows(InterruptedException.class,
-                () -> new Callback<>().await(100L, TimeUnit.MILLISECONDS));
+                () -> Callback.single().await(100L, TimeUnit.MILLISECONDS));
     }
 
     private void methodCallback(Callback<String> callback) {

--- a/src/test/java/dev/coly/util/TestCallback.java
+++ b/src/test/java/dev/coly/util/TestCallback.java
@@ -2,12 +2,16 @@ package dev.coly.util;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 public class TestCallback {
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("callbackInstances")
     public void testCallback() {
         Callback<String> callback = Callback.single();
         methodCallback(callback);
@@ -18,7 +22,8 @@ public class TestCallback {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("callbackInstances")
     public void testCallbackTimeout() {
         Callback<String> callback = Callback.single();
         methodCallback(callback);
@@ -29,14 +34,51 @@ public class TestCallback {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("callbackInstances")
     public void testCallbackTimeoutFailed() {
         Assertions.assertThrows(InterruptedException.class,
                 () -> Callback.single().await(100L, TimeUnit.MILLISECONDS));
     }
 
-    private void methodCallback(Callback<String> callback) {
+    @Test
+    public void testMultipleCallback() {
+        Callback<String> callback = Callback.multiple();
+        methodCallback(callback);
+        try {
+            Assertions.assertEquals("test", callback.await());
+        } catch (InterruptedException e) {
+            Assertions.fail(e);
+        }
+
+        methodCallback(callback);
+        callback.callback("test2");
+        try {
+            Assertions.assertEquals("test", callback.await());
+            Assertions.assertEquals("test2", callback.await());
+        } catch (InterruptedException e) {
+            Assertions.fail(e);
+        }
+    }
+
+    @Test
+    public void testMultipleCallbackLimit() {
+        Callback<String> callback = Callback.multiple(2);
+        methodCallback(callback);
+        methodCallback(callback);
+        Assertions.assertThrowsExactly(IllegalStateException.class, ()-> methodCallback(callback));
+    }
+
+    private static void methodCallback(Callback<String> callback) {
         callback.callback("test");
+    }
+
+    private static Stream<Callback> callbackInstances() {
+        return Stream.of(
+                Callback.single(),
+                Callback.multiple(),
+                Callback.multiple(5)
+        );
     }
 
 }


### PR DESCRIPTION
- Make Callback to interface
- Callback now have SingleCallback (original) and MultipleCallback (new)
- Added static method Callback.single() & Callback.multiple()
- MultipleCallback can set maximum limit of the object queue (The limit is link to the size of list that the Callback can hold, not total amount of call)